### PR TITLE
docs: update OpenAI integration documentation and add OpenAPI schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,16 +345,16 @@ curl -X POST http://localhost:8080/api/tools/assess_maturity \
 #### Option 2: Custom GPT Configuration
 Create a Custom GPT with action configuration:
 1. **Start HTTP Server**: Run `npm run start:http` to enable HTTP REST API mode
-2. **Base URL**: `http://localhost:8080/api/tools/`
+2. **Base URL**: `http://localhost`
 3. **Available Endpoints**: All 39 MCP tools available as HTTP endpoints
 4. **Authentication**: None required (configurable)
-5. **OpenAPI Schema**: Import the [openapi_3.1.0_actions.yaml](./openapi_3.1.0_actions.yaml) file when adding actions to your custom GPT
+5. **OpenAPI Schema**: Import the [openapi.yaml](./openapi.yaml) file when adding actions to your custom GPT
 
 ### Legacy: ChatGPT Integration (via MCP Connectors)
 
 For older integration methods, you can still use MCP-to-OpenAI connectors:
 
-#### Option 1: Using MCP Bridge
+#### Option 3: Using MCP Bridge
 ```bash
 # Install MCP Bridge (third-party connector)
 npm install -g @modelcontextprotocol/bridge
@@ -362,34 +362,12 @@ npm install -g @modelcontextprotocol/bridge
 # Start the bridge
 mcp-bridge --mcp-server http://localhost:3000 --openai-api-key YOUR_OPENAI_KEY
 ```
-
-#### Option 2: Using Custom Actions (ChatGPT Plus/Enterprise)
-Create a custom GPT with these server endpoints:
-
-**Base URL**: `http://localhost:3000` (or your deployed server URL)
-
-**Available Actions** (sample endpoints to configure):
-- `POST /tools/csf_lookup` - Look up CSF elements
-- `POST /tools/quick_assessment` - Perform rapid assessments  
-- `POST /tools/generate_report` - Generate comprehensive reports
-- `POST /tools/create_profile` - Create organization profiles
-
-**Authentication**: 
-- For development: No authentication required (`AUTH_MODE=disabled`)
-- For production: Use API key authentication (`AUTH_MODE=simple`)
-
-#### Option 3: Using Zapier or Make.com
+#### Option 4: Using Zapier or Make.com
 1. Create a webhook integration pointing to your server
 2. Configure triggers for specific NIST CSF assessment workflows
 3. Connect to ChatGPT via their respective ChatGPT integrations
 
 ### Other AI Assistants
-
-#### Google Gemini Integration
-Use the same MCP Bridge approach or create custom connectors using the server's REST-like interface.
-
-#### Microsoft Copilot Integration  
-Configure using Microsoft's connector framework with the MCP server endpoints.
 
 ### Enterprise Integration
 
@@ -412,15 +390,15 @@ AI Clients → API Gateway → NIST CSF 2.0 MCP Server → SQLite Database
 For high availability:
 ```bash
 # Multiple server instances
-npm start --port 3001
-npm start --port 3002
-npm start --port 3003
+npm start --port 8080
+npm start --port 8081
+npm start --port 8082
 ```
 
 ### Troubleshooting Connection Issues
 
 #### Common Issues:
-- **Connection Refused**: Ensure server is running on correct port
+- **Connection Refused**: Ensure server is running on the correct port
 - **Authentication Errors**: Check `AUTH_MODE` configuration matches client setup
 - **Tool Not Found**: Verify server build completed successfully (`npm run build`)
 - **Permission Errors**: Check file permissions for database and log files

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,1071 @@
+openapi: 3.1.0
+info:
+  title: NIST CSF 2.0 MCP Server API
+  description: Full HTTP REST API for interacting with the NIST CSF 2.0 MCP tools.
+  version: 1.0.0
+
+servers:
+  - url: https://localhost
+    description: Local MCP Server over TLS proxied to http://localhost:8080 via caddy
+
+paths:
+  /health:
+    get:
+      operationId: getHealthStatus
+      summary: Check MCP server health
+      responses:
+        '200':
+          description: Server health status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+        '400':
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/Error'
+        '500':
+          $ref: '#/components/responses/Error'
+
+  /api/tools:
+    get:
+      operationId: listTools
+      summary: List all available MCP tools
+      responses:
+        '200':
+          description: List of tools
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListToolsResponse'
+        '400':
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/Error'
+        '500':
+          $ref: '#/components/responses/Error'
+
+  /api/examples:
+    get:
+      operationId: getExamples
+      summary: Get example requests for common tools
+      responses:
+        '200':
+          description: Examples payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardResponse'
+        '400':
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/Error'
+        '500':
+          $ref: '#/components/responses/Error'
+
+  /api/tools/csf_lookup:
+    post:
+      operationId: csfLookup
+      summary: Look up NIST CSF 2.0 framework element by ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [element_id]
+              properties:
+                element_id:
+                  type: string
+      responses:
+        '200':
+          description: Framework element details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardResponse'
+        '400':
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/Error'
+        '500':
+          $ref: '#/components/responses/Error'
+
+  /api/tools/search_framework:
+    post:
+      operationId: searchFramework
+      summary: Search CSF framework elements by keyword
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [query]
+              properties:
+                query:
+                  type: string
+                limit:
+                  type: integer
+      responses:
+        '200':
+          description: Search results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardResponse'
+        '400':
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/Error'
+        '500':
+          $ref: '#/components/responses/Error'
+
+  /api/tools/get_related_subcategories:
+    post:
+      operationId: getRelatedSubcategories
+      summary: Get related CSF subcategories
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [subcategory_id]
+              properties:
+                subcategory_id:
+                  type: string
+                relationship_type:
+                  type: string
+      responses:
+        '200':
+          description: Related subcategories
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardResponse'
+        '400':
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/Error'
+        '500':
+          $ref: '#/components/responses/Error'
+
+  /api/tools/create_profile:
+    post:
+      operationId: createProfile
+      summary: Create a new organization profile
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [org_name, industry, size]
+              properties:
+                org_name:
+                  type: string
+                industry:
+                  type: string
+                size:
+                  type: string
+                current_tier:
+                  type: string
+                target_tier:
+                  type: string
+                description:
+                  type: string
+      responses:
+        '200':
+          description: Created profile
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardResponse'
+        '400':
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/Error'
+        '500':
+          $ref: '#/components/responses/Error'
+
+  /api/tools/start_assessment_workflow:
+    post:
+      operationId: startAssessmentWorkflow
+      summary: Start a new assessment workflow
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [org_name]
+              properties:
+                org_name:
+                  type: string
+                sector:
+                  type: string
+                size:
+                  type: string
+                contact_name:
+                  type: string
+                contact_email:
+                  type: string
+                assessment_scope:
+                  type: string
+                timeline_weeks:
+                  type: integer
+      responses:
+        '200':
+          description: Workflow started
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardResponse'
+        '400':
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/Error'
+        '500':
+          $ref: '#/components/responses/Error'
+
+  /api/tools/check_assessment_workflow_status:
+    post:
+      operationId: checkAssessmentWorkflowStatus
+      summary: Check status of an existing assessment workflow
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [workflow_id]
+              properties:
+                workflow_id:
+                  type: string
+      responses:
+        '200':
+          description: Workflow status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardResponse'
+        '400':
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/Error'
+        '500':
+          $ref: '#/components/responses/Error'
+
+  /api/tools/quick_assessment:
+    post:
+      operationId: quickAssessment
+      summary: Conduct a quick interactive cybersecurity assessment
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [profile_id]
+              properties:
+                profile_id:
+                  type: string
+                simplified_answers:
+                  type: object
+                  additionalProperties:
+                    type: string
+                assessed_by:
+                  type: string
+                confidence_level:
+                  type: string
+      responses:
+        '200':
+          description: Quick assessment response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardResponse'
+        '400':
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/Error'
+        '500':
+          $ref: '#/components/responses/Error'
+
+  /api/tools/assess_maturity:
+    post:
+      operationId: assessMaturity
+      summary: Perform a comprehensive maturity assessment
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [profile_id, assessment_scope]
+              properties:
+                profile_id:
+                  type: string
+                assessment_scope:
+                  type: string
+      responses:
+        '200':
+          description: Maturity assessment result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardResponse'
+        '400':
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/Error'
+        '500':
+          $ref: '#/components/responses/Error'
+
+  /api/tools/calculate_risk_score:
+    post:
+      operationId: calculateRiskScore
+      summary: Calculate organizational cybersecurity risk score
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [profile_id]
+              properties:
+                profile_id:
+                  type: string
+      responses:
+        '200':
+          description: Calculated risk score
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardResponse'
+        '400':
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/Error'
+        '500':
+          $ref: '#/components/responses/Error'
+
+  /api/tools/calculate_maturity_trend:
+    post:
+      operationId: calculateMaturityTrend
+      summary: Analyze maturity trends over a given time period
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [profile_id, time_period_months]
+              properties:
+                profile_id:
+                  type: string
+                time_period_months:
+                  type: integer
+      responses:
+        '200':
+          description: Maturity trend over time
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardResponse'
+        '400':
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/Error'
+        '500':
+          $ref: '#/components/responses/Error'
+
+  /api/tools/generate_gap_analysis:
+    post:
+      operationId: generateGapAnalysis
+      summary: Generate a gap analysis report for a profile
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [profile_id]
+              properties:
+                profile_id:
+                  type: string
+      responses:
+        '200':
+          description: Gap analysis results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardResponse'
+        '400':
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/Error'
+        '500':
+          $ref: '#/components/responses/Error'
+
+  /api/tools/generate_priority_matrix:
+    post:
+      operationId: generatePriorityMatrix
+      summary: Generate an implementation priority matrix
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [profile_id]
+              properties:
+                profile_id:
+                  type: string
+      responses:
+        '200':
+          description: Priority matrix results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardResponse'
+        '400':
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/Error'
+        '500':
+          $ref: '#/components/responses/Error'
+
+  /api/tools/create_implementation_plan:
+    post:
+      operationId: createImplementationPlan
+      summary: Generate a detailed implementation roadmap
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [profile_id, planning_horizon_months, resource_constraints, priority_focus]
+              properties:
+                profile_id:
+                  type: string
+                planning_horizon_months:
+                  type: integer
+                resource_constraints:
+                  type: object
+                  properties:
+                    budget:
+                      type: number
+                    staff_hours_per_month:
+                      type: integer
+                priority_focus:
+                  type: string
+      responses:
+        '200':
+          description: Implementation plan
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardResponse'
+        '400':
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/Error'
+        '500':
+          $ref: '#/components/responses/Error'
+
+  /api/tools/estimate_implementation_cost:
+    post:
+      operationId: estimateImplementationCost
+      summary: Estimate implementation costs for a profile
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [profile_id, cost_model]
+              properties:
+                profile_id:
+                  type: string
+                cost_model:
+                  type: string
+      responses:
+        '200':
+          description: Cost estimation result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardResponse'
+        '400':
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/Error'
+        '500':
+          $ref: '#/components/responses/Error'
+
+  /api/tools/suggest_next_actions:
+    post:
+      operationId: suggestNextActions
+      summary: Get AI-powered recommended next actions
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [profile_id, priority_level, resource_availability]
+              properties:
+                profile_id:
+                  type: string
+                priority_level:
+                  type: string
+                resource_availability:
+                  type: string
+      responses:
+        '200':
+          description: Suggested next actions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardResponse'
+        '400':
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/Error'
+        '500':
+          $ref: '#/components/responses/Error'
+
+  /api/tools/track_progress:
+    post:
+      operationId: trackProgress
+      summary: Update and track implementation progress
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [profile_id, updates]
+              properties:
+                profile_id:
+                  type: string
+                updates:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      subcategory_id:
+                        type: string
+                      current_implementation:
+                        type: string
+                      current_maturity:
+                        type: integer
+                      status:
+                        type: string
+                      notes:
+                        type: string
+      responses:
+        '200':
+          description: Progress tracking result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardResponse'
+        '400':
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/Error'
+        '500':
+          $ref: '#/components/responses/Error'
+
+  /api/tools/get_industry_benchmarks:
+    post:
+      operationId: getIndustryBenchmarks
+      summary: Retrieve industry benchmark data for a profile
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [profile_id, sector, organization_size]
+              properties:
+                profile_id:
+                  type: string
+                sector:
+                  type: string
+                organization_size:
+                  type: string
+      responses:
+        '200':
+          description: Industry benchmark results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardResponse'
+        '400':
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/Error'
+        '500':
+          $ref: '#/components/responses/Error'
+
+  /api/tools/generate_report:
+    post:
+      operationId: generateReport
+      summary: Generate a comprehensive report for a profile
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [profile_id, report_type]
+              properties:
+                profile_id:
+                  type: string
+                report_type:
+                  type: string
+                include_recommendations:
+                  type: boolean
+                include_charts:
+                  type: boolean
+      responses:
+        '200':
+          description: Generated report
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardResponse'
+        '400':
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/Error'
+        '500':
+          $ref: '#/components/responses/Error'
+
+  /api/tools/compare_profiles:
+    post:
+      operationId: compareProfiles
+      summary: Compare two organization profiles
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [profile1_id, profile2_id, comparison_type]
+              properties:
+                profile1_id:
+                  type: string
+                profile2_id:
+                  type: string
+                comparison_type:
+                  type: string
+      responses:
+        '200':
+          description: Comparison results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardResponse'
+        '400':
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/Error'
+        '500':
+          $ref: '#/components/responses/Error'
+
+  /api/tools/export_data:
+    post:
+      operationId: exportData
+      summary: Export assessment data for a profile
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [profile_id, export_format]
+              properties:
+                profile_id:
+                  type: string
+                export_format:
+                  type: string
+                include_metadata:
+                  type: boolean
+      responses:
+        '200':
+          description: Exported data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardResponse'
+        '400':
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/Error'
+        '500':
+          $ref: '#/components/responses/Error'
+
+  /api/tools/import_assessment:
+    post:
+      operationId: importAssessment
+      summary: Import external assessment data
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [profile_id, assessment_data]
+              properties:
+                profile_id:
+                  type: string
+                assessment_data:
+                  type: object
+                overwrite_existing:
+                  type: boolean
+      responses:
+        '200':
+          description: Imported assessment
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardResponse'
+        '400':
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/Error'
+        '500':
+          $ref: '#/components/responses/Error'
+
+  /api/tools/validate_evidence:
+    post:
+      operationId: validateEvidence
+      summary: Validate submitted evidence for assessment
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [profile_id, evidence_id]
+              properties:
+                profile_id:
+                  type: string
+                evidence_id:
+                  type: string
+      responses:
+        '200':
+          description: Evidence validation result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardResponse'
+        '400':
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/Error'
+        '500':
+          $ref: '#/components/responses/Error'
+
+  /api/tools/get_implementation_template:
+    post:
+      operationId: getImplementationTemplate
+      summary: Get implementation templates for subcategories
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [subcategory_id, industry, organization_size]
+              properties:
+                subcategory_id:
+                  type: string
+                industry:
+                  type: string
+                organization_size:
+                  type: string
+                include_examples:
+                  type: boolean
+                include_tools:
+                  type: boolean
+                include_metrics:
+                  type: boolean
+      responses:
+        '200':
+          description: Template response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardResponse'
+        '400':
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/Error'
+        '500':
+          $ref: '#/components/responses/Error'
+
+  /api/tools/generate_policy_template:
+    post:
+      operationId: generatePolicyTemplate
+      summary: Generate policy template for a subcategory
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [subcategory_id, industry, organization_size]
+              properties:
+                subcategory_id:
+                  type: string
+                industry:
+                  type: string
+                organization_size:
+                  type: string
+      responses:
+        '200':
+          description: Policy template response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardResponse'
+        '400':
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/Error'
+        '500':
+          $ref: '#/components/responses/Error'
+
+  /api/tools/generate_test_scenarios:
+    post:
+      operationId: generateTestScenarios
+      summary: Generate security test scenarios for a subcategory
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [subcategory_id, test_type]
+              properties:
+                subcategory_id:
+                  type: string
+                test_type:
+                  type: string
+                include_scripts:
+                  type: boolean
+                include_tools:
+                  type: boolean
+                severity_levels:
+                  type: array
+                  items:
+                    type: string
+                    enum: [medium, high, critical]
+      responses:
+        '200':
+          description: Generated test scenarios
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardResponse'
+        '400':
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/Error'
+        '500':
+          $ref: '#/components/responses/Error'
+
+  /api/tools/get_assessment_questions:
+    post:
+      operationId: getAssessmentQuestions
+      summary: Retrieve assessment questions for subcategories
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [assessment_type, organization_size, subcategory_ids]
+              properties:
+                assessment_type:
+                  type: string
+                organization_size:
+                  type: string
+                subcategory_ids:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        '200':
+          description: Retrieved questions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardResponse'
+        '400':
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/Error'
+        '500':
+          $ref: '#/components/responses/Error'
+
+  /api/tools/validate_assessment_responses:
+    post:
+      operationId: validateAssessmentResponses
+      summary: Validate responses submitted for assessment
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [profile_id, assessment_type, responses]
+              properties:
+                profile_id:
+                  type: string
+                assessment_type:
+                  type: string
+                responses:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      subcategory_id:
+                        type: string
+                      response_value:
+                        type: string
+                      evidence:
+                        type: string
+                      assessed_by:
+                        type: string
+                      confidence_level:
+                        type: string
+                require_all_questions:
+                  type: boolean
+                allow_partial_responses:
+                  type: boolean
+      responses:
+        '200':
+          description: Validation result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardResponse'
+        '400':
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/Error'
+        '500':
+          $ref: '#/components/responses/Error'
+
+components:
+  schemas:
+    StandardResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        data:
+          type: object
+          description: Tool-specific payload
+        timestamp:
+          type: string
+          format: date-time
+        tool:
+          type: string
+      required:
+        - success
+
+    ErrorResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          enum: [false]
+        error:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+        tool:
+          type: string
+      required:
+        - success
+        - error
+
+    HealthResponse:
+      type: object
+      properties:
+        status:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+        version:
+          type: string
+        mode:
+          type: string
+        tools_available:
+          type: integer
+      required:
+        - status
+
+    ToolListItem:
+      type: object
+      properties:
+        name:
+          type: string
+        endpoint:
+          type: string
+        method:
+          type: string
+        description:
+          type: string
+
+    ListToolsResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        tools_count:
+          type: integer
+        tools:
+          type: array
+          items:
+            $ref: '#/components/schemas/ToolListItem'
+        documentation:
+          type: object
+          properties:
+            openapi:
+              type: string
+            health:
+              type: string
+            examples:
+              type: string
+      required:
+        - success
+        - tools_count
+        - tools
+
+  responses:
+    Error:
+      description: Error response
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT


### PR DESCRIPTION
## Summary
- Update README.md with corrected OpenAI integration documentation
- Add openapi.yaml file for ChatGPT Actions integration
- Improve Custom GPT configuration instructions with numbered steps

## Changes Made
- **README.md**: Updated ChatGPT Integration section with:
  - Corrected base URL (localhost without port specification)
  - Numbered steps for Custom GPT Configuration
  - Reference to correct OpenAPI schema file (openapi.yaml)
  
- **openapi.yaml**: Added comprehensive OpenAPI 3.1.0 schema file for ChatGPT Actions integration

## Test plan
- [ ] Verify README.md displays correctly on GitHub
- [ ] Confirm OpenAPI schema file is accessible and valid
- [ ] Test ChatGPT Actions integration using new documentation

🤖 Generated with [Claude Code](https://claude.ai/code)