### PR TITLE
fix: update .dockerignore to prevent Docker build permission issues

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -37,6 +37,7 @@ Thumbs.db
 # Logs
 logs/
 *.log
+caddy.log
 
 # Documentation (except README)
 docs/


### PR DESCRIPTION
## Summary
Fix Docker build permission issues by updating .dockerignore to explicitly exclude caddy.log file

## Problem
Docker build was failing with permission denied errors when trying to read caddy.log file during build context loading.

## Solution
- Add explicit `caddy.log` exclusion to .dockerignore
- This prevents the Docker build process from trying to access files with restrictive permissions

## Changes Made
- **`.dockerignore`**: Added `caddy.log` to the logs exclusion section

## Test plan
- [ ] Verify Docker build completes successfully without permission errors
- [ ] Confirm log files are properly excluded from Docker build context

🤖 Generated with [Claude Code](https://claude.ai/code)